### PR TITLE
LUM-3464 Pie chart label names can overlap - the "direct previous label" can be the first label if this is the last label

### DIFF
--- a/src/models/pie.js
+++ b/src/models/pie.js
@@ -294,10 +294,9 @@ nv.models.pie = function() {
                                 var previousWidth = previousCenters[pc].width;
                                 if (Math.abs(center[0] - previousCenter[0]) < (width + previousWidth)/2 && Math.abs(center[1] - previousCenter[1]) < labelHeight) {
                                     // If the labels seem to overlap horizontally and vertically, take action
-                                    if (pc === previousCenters.length - 1) {
+                                    if (pc === previousCenters.length - 1 || i === labelsArc.length - 1 && pc === 0) {
                                         // If the label is overlapping with the direct previous label,
                                         // then move it up or down depending on which part of the circle it's on.
-                                        // Ideally, we'd move it out along the radius, but I'm not 100% sure how to do that (math!)
                                         if ((d.startAngle + d.endAngle) / 2 < Math.PI) {
                                             center[1] = previousCenter[1] + labelHeight;
                                         } else {
@@ -305,7 +304,6 @@ nv.models.pie = function() {
                                         }
                                     } else {
                                         // If the label is overlapping with an indirect predecessor, just move it horizontally.
-                                        // Again, ideally, we'd move it out along the radius, but I'm not 100% sure how to do that (math!)
                                         center[0] = previousCenter[0] - (width + previousWidth)/2;
                                     }
                                 }


### PR DESCRIPTION
Fix where the last label is getting pushed left out of the widget area